### PR TITLE
docs: Add task for writing CLC test suite

### DIFF
--- a/docs/TASK-write-test-suite.md
+++ b/docs/TASK-write-test-suite.md
@@ -13,11 +13,7 @@ The CLC project has 23 test files in `tests/` but many have issues (missing impo
 **Legacy Test Mapping:** Each priority section below includes a list of legacy test files it replaces. Delete these files as the new tests are completed and verified.
 
 **Legacy Test Inventory (23 files):**
-- **To replace** (10 files): Listed in each priority section below
-- **Mapped to priorities** (6 files):
-  - Priority 1 (Query): `test_sqlite_edge_cases.py`, `test_meta_observer.py` - database edge cases and observability
-  - Priority 3 (Conductor): `test_crash_recovery.py`, `test_dependency_graph.py` - workflow resilience
-  - Priority 5 (Non-Functional): `test_stress.py`, `test_lifecycle_adversarial.py` - performance and security
+- **To be replaced** (16 files): These files will be replaced by the new test suite and are listed under the `Replaces:` directive in each priority section below.
 - **To evaluate** (5 files): `test_baseline_refresh.py`, `test_destructive_edge_cases.py`, `test_domain_elasticity.py`, `test_integration_multiagent.py`, `test_temporal_smoothing.py` - assess during implementation whether these can be salvaged or should be replaced
 - **Pytest infrastructure** (2 files): `conftest.py` (will be replaced with new fixtures), `__init__.py` (keep as package marker)
 


### PR DESCRIPTION
## Summary

Adds a task document tracking the work needed to write a proper test suite for CLC core components.

## Details

Created `docs/TASK-write-test-suite.md` which outlines:
- Current state of tests (23 files, many broken)
- Priority order for new tests (query → hooks → conductor → dashboard)
- Technical approach (pytest, in-memory SQLite, proper fixtures)
- Acceptance criteria

This follows the recommendation from PR #1 to tackle tests in a separate focused effort.

/gemini review