### PR TITLE
refactor(dashboard): hide non-functional timeline playback controls

### DIFF
--- a/dashboard-app/frontend/src/components/TimelineView.tsx
+++ b/dashboard-app/frontend/src/components/TimelineView.tsx
@@ -26,6 +26,15 @@ const eventConfig = {
   workflow_run: { icon: Play, color: 'bg-slate-500', label: 'Workflow Run' },
 }
 
+/**
+ * Feature flag for playback controls.
+ * Hidden until session replay features are implemented.
+ * See: https://github.com/haighd/claude-learning-companion/issues/25 (Session Replay)
+ *      https://github.com/haighd/claude-learning-companion/issues/26 (Time-Scrubbing)
+ *      https://github.com/haighd/claude-learning-companion/issues/27 (Debug Stepping)
+ */
+const ENABLE_PLAYBACK_CONTROLS = false
+
 export default function TimelineView({ events, heuristics, onEventClick }: TimelineViewProps) {
   const [isPlaying, setIsPlaying] = useState(false)
   const [playbackIndex, setPlaybackIndex] = useState(0)
@@ -146,12 +155,9 @@ export default function TimelineView({ events, heuristics, onEventClick }: Timel
           <span className="text-sm text-slate-400">({events.length} events)</span>
         </div>
 
-        {/* Playback controls - hidden until session replay features are implemented
-            See: https://github.com/haighd/claude-learning-companion/issues/25 (Session Replay)
-                 https://github.com/haighd/claude-learning-companion/issues/26 (Time-Scrubbing)
-                 https://github.com/haighd/claude-learning-companion/issues/27 (Debug Stepping)
-        {false && (
-          <>
+        {/* Playback controls - hidden via ENABLE_PLAYBACK_CONTROLS feature flag */}
+        {ENABLE_PLAYBACK_CONTROLS && (
+          <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2 bg-slate-700 rounded-lg p-1">
               <button
                 onClick={handleSkipBack}
@@ -192,9 +198,8 @@ export default function TimelineView({ events, heuristics, onEventClick }: Timel
                 <span>{orderedEvents.length}</span>
               </div>
             )}
-          </>
+          </div>
         )}
-        End playback controls */}
 
         <div className="flex items-center space-x-4">
           {/* Filter */}

--- a/dashboard-app/frontend/src/utils/formatDate.ts
+++ b/dashboard-app/frontend/src/utils/formatDate.ts
@@ -15,8 +15,9 @@ import { format, formatDistanceToNow } from 'date-fns'
 export function parseUTCTimestamp(timestamp: string | null | undefined): Date | null {
   if (!timestamp) return null
 
-  // If already has timezone indicator, parse directly
-  if (timestamp.endsWith('Z') || timestamp.includes('+') || timestamp.includes('-')) {
+  // If already has timezone indicator (Z suffix or +HH:MM / -HH:MM offset), parse directly
+  const timezoneOffsetRegex = /[+-]\d{2}:\d{2}$/
+  if (timestamp.endsWith('Z') || timezoneOffsetRegex.test(timestamp)) {
     return new Date(timestamp)
   }
 


### PR DESCRIPTION
## Summary

- Hides the play/rewind/fast-forward controls in the Timeline tab
- Controls were UI scaffolding without actual functionality (users could scroll to achieve same effect)
- Code preserved (not deleted) pending implementation of replay features
- Adds `formatDate` utility for consistent timestamp handling

## Related Issues

Tracking issues created for the features that would make these controls useful:
- #25 Session Replay
- #26 Synchronized Time-Scrubbing
- #27 Debug Stepping

## Test plan

- [ ] Timeline tab loads without playback controls visible
- [ ] Event filtering still works
- [ ] Event clicking still works
- [ ] Build passes