### PR TITLE
fix(hooks): add clc path for conductor utils import

### DIFF
--- a/hooks/learning-loop/post_tool_learning.py
+++ b/hooks/learning-loop/post_tool_learning.py
@@ -966,6 +966,7 @@ def main():
         # - A non-trivial command (record regardless of outcome), or
         # - A trivial command that failed (outcome == "failure")
         try:
+            sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
             sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
             from conductor import Conductor, Node
 
@@ -1023,6 +1024,7 @@ def main():
         outcome, reason = determine_mcp_outcome(tool_input, tool_output)
 
         try:
+            sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
             sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
             from conductor import Conductor, Node
 
@@ -1085,6 +1087,7 @@ def main():
         outcome, reason = determine_webfetch_outcome(tool_input, tool_output)
 
         try:
+            sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
             sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
             from conductor import Conductor, Node
 
@@ -1166,6 +1169,7 @@ def main():
         if pending and pending.get('run_id') and pending.get('exec_id'):
             # Complete the existing workflow run
             try:
+                sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
                 sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
                 from conductor import Conductor
 
@@ -1225,6 +1229,7 @@ def main():
             # No pending task found - create new workflow record
             sys.stderr.write(f"[LEARNING_LOOP] No pending task for {task_id}, creating new workflow record\n")
             try:
+                sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
                 sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
                 from conductor import Conductor, Node
 
@@ -1311,6 +1316,7 @@ def main():
 
             # Create workflow run and record as pending
             try:
+                sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
                 sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
                 from conductor import Conductor, Node
 
@@ -1363,6 +1369,7 @@ def main():
             outcome, reason = determine_outcome(tool_output)
 
             try:
+                sys.path.insert(0, str(Path.home() / '.claude' / 'clc'))
                 sys.path.insert(0, str(Path.home() / '.claude' / 'clc' / 'conductor'))
                 from conductor import Conductor, Node
 


### PR DESCRIPTION
## Summary

Fixes workflow runs not being recorded since commit 585ce37 (Dec 21).

### Root Cause
- Commit 585ce37 added `from utils.module_loader import get_module_attribute` to `conductor/conductor.py`
- The `utils/` directory lives at `~/.claude/clc/utils/`
- The post_tool_learning.py hook only added `~/.claude/clc/conductor/` to sys.path
- Result: `No module named 'utils.module_loader'` error, causing silent failure

### Fix
Add `~/.claude/clc` to sys.path before the conductor import at all 7 locations where the Conductor is imported.

### Impact
- All agent runs since Dec 21 19:08 were not recorded
- After this fix, runs are being recorded again (verified: runs 4879-4882 created)

## Test plan
- [x] Tested hook manually with echo pipe - no import errors
- [x] Verified new workflow runs are being created in index.db