### PR TITLE
feat(ci): Phase 1 Foundation - disk cleanup and dual-reviewer awareness

### DIFF
--- a/.github/workflows/gemini-review-check.yml
+++ b/.github/workflows/gemini-review-check.yml
@@ -55,16 +55,11 @@ jobs:
             });
 
             // Check Copilot status (auto-triggered via ruleset)
+            // Copilot's reviewer bot uses 'copilot-pull-request-reviewer[bot]' login
             const copilotReviewed = allComments.some((comment) => {
-              return comment.user && (
-                comment.user.login.includes('copilot') ||
-                comment.user.login === 'github-actions[bot]'
-              );
+              return comment.user && comment.user.login.includes('copilot');
             }) || reviews.some((review) => {
-              return review.user && (
-                review.user.login.includes('copilot') ||
-                review.body && review.body.includes('Copilot reviewed')
-              );
+              return review.user && review.user.login.includes('copilot');
             });
 
             // Log status

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true
@@ -89,12 +89,13 @@ jobs:
         run: |
           echo "Available disk space:"
           df -h /
-          AVAIL=$(df / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
-          if [ "${AVAIL%.*}" -lt 10 ]; then
-            echo "::error::Less than 10GB available. Failing early."
+          # Use --block-size=1G for consistent GB output regardless of size
+          AVAIL=$(df --block-size=1G / | awk 'NR==2 {print $4}')
+          if [ "$AVAIL" -lt 10 ]; then
+            echo "::error::Less than 10GB available ($AVAIL GB). Failing early."
             exit 1
           fi
-          echo "✓ Sufficient disk space available"
+          echo "✓ Sufficient disk space available ($AVAIL GB)"
 
       - name: Checkout PR
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Implements Phase 1 (Foundation) of the unified CI/CD workflow from Issue #49.

### Changes

**Disk Cleanup (Task 1.2)**
- Added `jlumbroso/free-disk-space` action to `run-ci.yml`
- Removes Android SDK, .NET, Haskell, large packages (~20GB freed)
- Adds 10GB threshold check to fail fast if insufficient space
- Prevents CI failures due to disk exhaustion

**Dual-Reviewer Awareness (Task 1.4)**
- Updated `gemini-review-check.yml` → `Ensure AI Reviews`
- Logs status of both Gemini and Copilot reviewers
- Shows reviewer status table in trigger comment
- Copilot is auto-triggered via repository ruleset (configured separately)

### Already Complete (from PR #50)
- Thread check integration (Task 1.5) - CI gates on unresolved threads

### Dependencies Completed by CEO
- [x] `haighd-bot` account created with PAT stored as `BOT_PAT` secret
- [x] Copilot automatic review ruleset configured

## Test plan

- [ ] Verify disk cleanup step runs and frees space (check CI logs)
- [ ] Verify Gemini trigger comment includes reviewer status table
- [ ] Verify Copilot auto-reviews on PR creation (via ruleset)
- [ ] Verify CI still gates on unresolved threads

## Next Steps (Phase 2)

After this merges, Phase 2 will add:
- Auto-approval workflow using `haighd-bot`
- `ready-to-merge` label after bot approval
- CEO notification consolidation

Related: #49